### PR TITLE
Advance Tooltip Item Mods On Key Press

### DIFF
--- a/src/Hud/AdvancedTooltip/AdvancedTooltipPlugin.cs
+++ b/src/Hud/AdvancedTooltip/AdvancedTooltipPlugin.cs
@@ -51,6 +51,17 @@ namespace PoeHUD.Hud.AdvancedTooltip
                 {
                     holdKey = false;
                 }
+                if (Settings.ItemMods.ToggleModsOnHold)
+                {
+                    if (!WinApi.IsKeyDown(Settings.ItemMods.ModKey))
+                    {
+                        Settings.ItemMods.Enable = false;
+                    }
+                    else
+                    {
+                        Settings.ItemMods.Enable = true;
+                    }
+                }
                 Element uiHover = GameController.Game.IngameState.UIHover;
                 var inventoryItemIcon = uiHover.AsObject<HoverItemIcon>();
                 if (inventoryItemIcon == null)

--- a/src/Hud/AdvancedTooltip/ItemModsSettings.cs
+++ b/src/Hud/AdvancedTooltip/ItemModsSettings.cs
@@ -1,4 +1,5 @@
-﻿using PoeHUD.Hud.Settings;
+﻿using System.Windows.Forms;
+using PoeHUD.Hud.Settings;
 using SharpDX;
 
 namespace PoeHUD.Hud.AdvancedTooltip
@@ -15,6 +16,8 @@ namespace PoeHUD.Hud.AdvancedTooltip
             T1Color = new ColorBGRA(255, 0, 255, 255);
             T2Color = new ColorBGRA(255, 255, 0, 255);
             T3Color = new ColorBGRA(0, 255, 0, 255);
+            ToggleModsOnHold = false;
+            ModKey = Keys.LControlKey;
         }
 
         public RangeNode<int> ModTextSize { get; set; }
@@ -24,5 +27,7 @@ namespace PoeHUD.Hud.AdvancedTooltip
         public ColorNode T1Color { get; set; }
         public ColorNode T2Color { get; set; }
         public ColorNode T3Color { get; set; }
+        public ToggleNode ToggleModsOnHold { get; set; }
+        public HotkeyNode ModKey { get; set; }
     }
 }

--- a/src/Hud/Menu/MenuPlugin.cs
+++ b/src/Hud/Menu/MenuPlugin.cs
@@ -234,6 +234,8 @@ namespace PoeHUD.Hud.Menu
             AddChild(itemModsMenu, "Tier 3 color", settingsHub.AdvancedTooltipSettings.ItemMods.T3Color);
             AddChild(itemModsMenu, "Suffix color", settingsHub.AdvancedTooltipSettings.ItemMods.SuffixColor);
             AddChild(itemModsMenu, "Prefix color", settingsHub.AdvancedTooltipSettings.ItemMods.PrefixColor);
+            MenuItem toggleModsMenu = AddChild(itemModsMenu, "Mods On Key Press", settingsHub.AdvancedTooltipSettings.ItemMods.ToggleModsOnHold);
+            MenuItem toggleModsKey = AddChild(toggleModsMenu, "Select Key", settingsHub.AdvancedTooltipSettings.ItemMods.ModKey);
             MenuItem weaponDpsMenu = AddChild(tooltipMenu, "Weapon Dps", settingsHub.AdvancedTooltipSettings.WeaponDps.Enable);
             MenuItem damageColors = AddChild(weaponDpsMenu, "Damage colors", settingsHub.AdvancedTooltipSettings.WeaponDps.Enable);
             AddChild(damageColors, "Cold damage", settingsHub.AdvancedTooltipSettings.WeaponDps.DmgColdColor);


### PR DESCRIPTION
Added options for the AdvanceTooltip plugin to allow for turning on item mods during key press. Default key is LControl. Off by default.